### PR TITLE
De-emphasise European focus; correct spelling of "modelling"

### DIFF
--- a/index.html
+++ b/index.html
@@ -37,7 +37,7 @@
 <div class="row" >
         <div class="col-sm-3">
           <h2>About</h2>
-          <p>We are a grass root initiative of modellers from various universities and research institutes across Europe.  </p>
+          <p>We are a grass root initiative of modellers from various universities and research institutes across the world.  </p>
 <!--           <p><a href=" http://wiki.openmod-initiative.org/wiki/Special:Usergallery?wpIlReset=Show%20all" target="_blank">View  members &raquo;</a></p> -->
         </div>
         <div class="col-sm-3">

--- a/manifesto.html
+++ b/manifesto.html
@@ -37,17 +37,17 @@
 <div class="row" >
         <div class="col-sm-8">
           <h2>Openmod in a nutshell</h2>
-          <p>The Open Energy Modelling (openmod) Initiative promotes open energy modelling in Europe. </p>
+          <p>The Open Energy Modelling (openmod) Initiative promotes open energy modelling across the world. </p>
           </p>Energy models are widely used for policy advice and research. They serve to help answer questions on energy policy, decarbonization, and transitions towards renewable energy sources. Currently, most energy models are black boxes – even to fellow researchers.</p>
           <p>“Open” refers to model source code that can be studied, changed and improved as well as freely available energy system data.</p>
           <p>We believe that more openness in energy modelling increases transparency and credibility, reduces wasteful double-work and improves overall quality. This allows the community to advance the research frontier and gain the highest benefit from energy modelling for society.</p>
-          <p>We, energy modelers from various institutions, want to promote the idea and practice of open energy modeling among fellow modelers, research institutions, funding bodies, and recipients of our work.</p>
+          <p>We, energy modelers from various institutions, want to promote the idea and practice of open energy modelling among fellow modelers, research institutions, funding bodies, and recipients of our work.</p>
 
           <h2>The idea of openmod</h2>
                    <img src="img/open-model-process.png" width="100%">
 
           <p>Not only the number but also the complexity of energy system models has increased in recent years. This was driven by ongoing research and the development of better software and hardware, which enables faster computation speed. Such energy models serve as laboratories for future energy systems and are necessary for research, prognoses and optimization. </p>
-          <p>With increasing shares of intermittent renewables and other innovative technologies the demand for insights provided by energy system models will increase. Even though there exists a wealth of models on the German and European electricity system, many modeling challenges persist.
+          <p>With increasing shares of intermittent renewables and other innovative technologies the demand for insights provided by energy system models will increase. Even though there exists, for example, a wealth of models of the German and European electricity system, many modelling challenges persist. </p>
           <p>Developing and advancing an energy system model is a very lengthy and time-consuming process. Especially data research and pre-processing dissipates significant resources.</p>
           <p>Required input data as well as code overlap to a large extent for the models of different research groups. Nevertheless, almost all of them conduct data collection and source coding in parallel isolation. Most of the data and code is proprietary and can neither be scrutinized nor used and improved by the scientific community.</p>
           <p>Our idea is to open the whole energy modelling process by utilizing open data and open source code. We want to share our modelling work for the sake of efficiency and quality. Fulfilling scientific standards of transparency and reproducibility leads to higher quality and credibility. Furthermore, extensive collaboration allows energy system researchers to focus on answering the essential questions instead of just developing the tool.</p>
@@ -64,7 +64,7 @@
         </div>
         <div class="col-sm-4">
           <h2>The vision of openmod</h2>
-          We want to advance open energy system modeling by
+          We want to advance open energy system modelling by
           <h3>Community</h3>
           <ul>
             <li>offering a hub for actively sharing data and code</li>


### PR DESCRIPTION
Openmod has members from North America, Africa, Asia and Australia.

Use consistent British spelling of "modelling".